### PR TITLE
Add resourceUri to UsageEvent

### DIFF
--- a/Microsoft.Marketplace.Metering/2018-08-31/meteringapi.v1.json
+++ b/Microsoft.Marketplace.Metering/2018-08-31/meteringapi.v1.json
@@ -191,7 +191,11 @@
           "resourceId": {
             "type": "string",
             "format": "uuid",
-            "description": "Subscription ID for the event"
+            "description": "Subscription ID for the event. Used with SaaS applications."
+          },
+          "resourceUri": {
+            "type": "string",
+            "description": "Resource URI for the managed app. Used with managed applications."
           },
           "quantity": {
             "type": "integer",
@@ -256,6 +260,10 @@
             "type": "string",
             "format": "uuid"
           },
+          "resourceUri": {
+            "description": "Identifier of the managed app resource against which usage is emitted",
+            "type": "string"
+          },
           "quantity": {
             "description": "Number of units consumed",
             "type": "integer",
@@ -310,6 +318,10 @@
                 "description": "Identifier of the resource against which usage is emitted",
                 "type": "string",
                 "format": "uuid"
+              },
+              "resourceUri": {
+                "description": "Identifier of the managed app resource against which usage is emitted",
+                "type": "string"
               },
               "quantity": {
                 "type": "integer",

--- a/Microsoft.Marketplace.Metering/2018-08-31/meteringapi.v1.json
+++ b/Microsoft.Marketplace.Metering/2018-08-31/meteringapi.v1.json
@@ -191,11 +191,11 @@
           "resourceId": {
             "type": "string",
             "format": "uuid",
-            "description": "Subscription ID for the event. Used with SaaS applications."
+            "description": "subscriptionId property value for SaaS offer subscriptions; resourceUsageId property on the managed application resource for managed application offers. For managed applications, only use one of resourceId or resourceUri."
           },
           "resourceUri": {
             "type": "string",
-            "description": "Resource URI for the managed app. Used with managed applications."
+            "description": "Resource URI for the managed app. Used with managed applications. Only use resourceUri or resourceId, but never both."
           },
           "quantity": {
             "type": "integer",


### PR DESCRIPTION
I have confirmed that the resourceUri works fine on the request.
I have generated an error (submitting the same request twice) and confirmed that the error response includes both the resourceId and the resourceUri for the managed app.
This builds fine against my Python client.